### PR TITLE
Add article extraction using Readability

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -1,0 +1,9 @@
+# Extension
+
+This folder contains the Chrome extension source for Political Perspectives.
+
+## Article Extraction
+
+The content script now uses `@mozilla/readability` to extract the main article text from the page. The sidebar requests this via the `PP_EXTRACT_ARTICLE` action and displays the extracted text beneath the current article information.
+
+Run tests with `npm test` inside this directory.

--- a/extension/package.json
+++ b/extension/package.json
@@ -5,11 +5,13 @@
   "type": "module",
   "scripts": {
     "dev": "vite build --watch",
-    "build": "vite build"
+    "build": "vite build",
+    "test": "vitest run"
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "@mozilla/readability": "^0.5.0"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.268",
@@ -21,6 +23,8 @@
     "eslint": "^9.26.0",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-react": "^7.37.5",
-    "prettier": "^3.5.3"
+    "prettier": "^3.5.3",
+    "vitest": "^1.5.0",
+    "jsdom": "^24.0.0"
   }
 }

--- a/extension/tests/extraction.test.ts
+++ b/extension/tests/extraction.test.ts
@@ -1,0 +1,22 @@
+import { Readability } from '@mozilla/readability';
+import { JSDOM } from 'jsdom';
+
+function runReadability(html: string): string | null {
+  const dom = new JSDOM(html);
+  const article = new Readability(dom.window.document).parse();
+  return article?.textContent ?? null;
+}
+
+describe('Readability extraction', () => {
+  it('extracts content from simple HTML', () => {
+    const html = `<html><body><article><h1>Hi</h1><p>Test</p></article></body></html>`;
+    const text = runReadability(html);
+    expect(text?.trim()).toBe('Hi\nTest');
+  });
+
+  it('returns null on empty page', () => {
+    const html = `<html><body></body></html>`;
+    const text = runReadability(html);
+    expect(text).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- integrate `@mozilla/readability` into the extension
- implement `extractArticleContent` and new message action
- fetch extracted text in the sidebar and show it under the article info
- add basic Vitest tests for extraction
- document the behaviour in `extension/README.md`

## Testing
- `npm test --silent` *(fails: vitest not found)*