### PR TITLE
Add minimal FastAPI backend skeleton

### DIFF
--- a/backend/infra/Dockerfile
+++ b/backend/infra/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY .. /app
+RUN pip install --no-cache-dir fastapi uvicorn[standard]
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/backend/infra/cloudrun.yaml
+++ b/backend/infra/cloudrun.yaml
@@ -1,0 +1,11 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: backend
+spec:
+  template:
+    spec:
+      containers:
+        - image: gcr.io/PROJECT_ID/backend:latest
+          ports:
+            - containerPort: 8080

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI
+
+from backend.services.dedup import router as dedup_router
+from backend.services.retrieval import router as retrieval_router
+from backend.services.topics import router as topics_router
+
+app = FastAPI()
+
+app.include_router(topics_router, prefix="/topics", tags=["topics"])
+app.include_router(retrieval_router, prefix="/search", tags=["search"])
+app.include_router(dedup_router, prefix="/dedup", tags=["dedup"])
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/backend/services/dedup/__init__.py
+++ b/backend/services/dedup/__init__.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter
+
+from backend.shared.models import DedupRequest, DedupResponse
+
+router = APIRouter()
+
+
+class Deduplicator:
+    """Placeholder deduplicator."""
+
+    @staticmethod
+    def group_by_simhash(items: list[str]) -> list[list[str]]:
+        groups: list[list[str]] = []
+        for item in items:
+            for group in groups:
+                if group[0] == item:
+                    group.append(item)
+                    break
+            else:
+                groups.append([item])
+        return groups
+
+
+@router.post("/", response_model=DedupResponse)
+def group(request: DedupRequest) -> DedupResponse:
+    groups = Deduplicator.group_by_simhash(request.items)
+    return DedupResponse(groups=groups)

--- a/backend/services/retrieval/__init__.py
+++ b/backend/services/retrieval/__init__.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter
+
+from backend.shared.models import SearchRequest, SearchResponse
+
+router = APIRouter()
+
+
+class SearchAggregator:
+    """Placeholder search aggregator."""
+
+    @staticmethod
+    def search(query: str) -> list[str]:
+        return [query, f"{query} result"]
+
+
+@router.post("/", response_model=SearchResponse)
+def search(request: SearchRequest) -> SearchResponse:
+    results = SearchAggregator.search(request.query)
+    return SearchResponse(results=results)

--- a/backend/services/topics/__init__.py
+++ b/backend/services/topics/__init__.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter
+
+from backend.shared.models import TopicRequest, TopicResponse
+
+router = APIRouter()
+
+
+class TopicDetector:
+    """Placeholder topic detector."""
+
+    @staticmethod
+    def get_topics(text: str) -> list[str]:
+        words = text.split()
+        return list(dict.fromkeys(words))[:3]
+
+
+@router.post("/", response_model=TopicResponse)
+def detect_topics(request: TopicRequest) -> TopicResponse:
+    topics = TopicDetector.get_topics(request.text)
+    return TopicResponse(topics=topics)

--- a/backend/shared/models.py
+++ b/backend/shared/models.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import List
+
+from pydantic import BaseModel
+
+
+class TopicRequest(BaseModel):
+    text: str
+
+
+class TopicResponse(BaseModel):
+    topics: List[str]
+
+
+class SearchRequest(BaseModel):
+    query: str
+
+
+class SearchResponse(BaseModel):
+    results: List[str]
+
+
+class DedupRequest(BaseModel):
+    items: List[str]
+
+
+class DedupResponse(BaseModel):
+    groups: List[List[str]]

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -1,0 +1,29 @@
+import unittest
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+
+class APITestCase(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+
+    def test_topics(self):
+        response = self.client.post("/topics/", json={"text": "hello world hello"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"topics": ["hello", "world"]})
+
+    def test_search(self):
+        response = self.client.post("/search/", json={"query": "news"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"results": ["news", "news result"]})
+
+    def test_dedup(self):
+        response = self.client.post("/dedup/", json={"items": ["a", "a", "b"]})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"groups": [["a", "a"], ["b"]]})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- scaffold backend services for topics, retrieval and dedup
- add FastAPI `main.py` that wires the routers
- define request and response models
- include Dockerfile and Cloud Run config
- add unit tests hitting each endpoint

## Testing
- `python -m unittest discover backend/tests` *(fails: ModuleNotFoundError: No module named 'httpx')*