### PR TITLE
Implement spaCy-based topic detector

### DIFF
--- a/backend/infra/Dockerfile
+++ b/backend/infra/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY .. /app
-RUN pip install --no-cache-dir fastapi uvicorn[standard]
+RUN pip install --no-cache-dir fastapi uvicorn[standard] spacy \
+    && python -m spacy download en_core_web_sm
 CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/backend/services/topics/__init__.py
+++ b/backend/services/topics/__init__.py
@@ -1,17 +1,37 @@
+import spacy
 from fastapi import APIRouter
 
 from backend.shared.models import TopicRequest, TopicResponse
+
+_nlp = None
 
 router = APIRouter()
 
 
 class TopicDetector:
-    """Placeholder topic detector."""
+    """Simple topic detector using spaCy."""
 
     @staticmethod
     def get_topics(text: str) -> list[str]:
-        words = text.split()
-        return list(dict.fromkeys(words))[:3]
+        global _nlp
+        if _nlp is None:
+            _nlp = spacy.load("en_core_web_sm")
+
+        doc = _nlp(text)
+        topics: list[str] = []
+        seen: set[str] = set()
+
+        for ent in doc.ents:
+            if ent.label_ in {"PERSON", "ORG", "GPE", "LOC"}:
+                if ent.text not in seen:
+                    topics.append(ent.text)
+                    seen.add(ent.text)
+        for chunk in doc.noun_chunks:
+            if chunk.text not in seen:
+                topics.append(chunk.text)
+                seen.add(chunk.text)
+
+        return topics[:3]
 
 
 @router.post("/", response_model=TopicResponse)

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -10,9 +10,13 @@ class APITestCase(unittest.TestCase):
         self.client = TestClient(app)
 
     def test_topics(self):
-        response = self.client.post("/topics/", json={"text": "hello world hello"})
+        text = "Barack Obama met Angela Merkel in Berlin."
+        response = self.client.post("/topics/", json={"text": text})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {"topics": ["hello", "world"]})
+        self.assertEqual(
+            response.json(),
+            {"topics": ["Barack Obama", "Angela Merkel", "Berlin"]},
+        )
 
     def test_search(self):
         response = self.client.post("/search/", json={"query": "news"})


### PR DESCRIPTION
## Summary
- add `spacy` and download English model in Dockerfile
- detect topics using spaCy NER and noun phrases
- expect named entities in tests instead of word splits

## Testing
- `isort .`
- `black .`
- `python -m unittest discover tests` *(fails: No module named 'httpx')*