### PR TITLE
Add summarization and bias services

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,10 @@
 from fastapi import FastAPI
 
+from backend.services.bias import router as bias_router
 from backend.services.dedup import router as dedup_router
 from backend.services.extract import router as extract_router
 from backend.services.retrieval import router as retrieval_router
+from backend.services.summarize import router as summarize_router
 from backend.services.topics import router as topics_router
 
 app = FastAPI()
@@ -11,6 +13,8 @@ app.include_router(topics_router, prefix="/topics", tags=["topics"])
 app.include_router(retrieval_router, prefix="/search", tags=["search"])
 app.include_router(dedup_router, prefix="/dedup", tags=["dedup"])
 app.include_router(extract_router, prefix="/extract", tags=["extract"])
+app.include_router(summarize_router, prefix="/summarize", tags=["summarize"])
+app.include_router(bias_router, prefix="/bias", tags=["bias"])
 
 if __name__ == "__main__":
     import uvicorn

--- a/backend/services/bias/__init__.py
+++ b/backend/services/bias/__init__.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from backend.shared.models import BiasRequest, BiasResponse
+
+router = APIRouter()
+
+
+class BiasAnnotator:
+    """Simple bias annotator using a predefined source map."""
+
+    _BIAS_MAP = {
+        "Fox News": ("Right", 10),
+        "MSNBC": ("Left", 10),
+        "AP": ("Center", 5),
+    }
+
+    @classmethod
+    def annotate(cls, source: str) -> BiasResponse:
+        bias, score = cls._BIAS_MAP.get(source, ("Center", 0))
+        return BiasResponse(bias=bias, bias_score=score)
+
+
+@router.post("/", response_model=BiasResponse)
+def bias_endpoint(request: BiasRequest) -> BiasResponse:
+    return BiasAnnotator.annotate(request.source)

--- a/backend/services/summarize/__init__.py
+++ b/backend/services/summarize/__init__.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import re
+
+from fastapi import APIRouter
+
+from backend.shared.models import SummarizeRequest, SummarizeResponse
+
+router = APIRouter()
+
+
+class Summarizer:
+    """Very naive text summarizer using sentence splitting."""
+
+    @staticmethod
+    def summarize(text: str, max_sentences: int = 3) -> str:
+        sentences = re.findall(r"[^.!?]+[.!?]", text)
+        summary = " ".join(s.strip() for s in sentences[:max_sentences])
+        return summary.strip()
+
+
+@router.post("/", response_model=SummarizeResponse)
+def summarize_endpoint(request: SummarizeRequest) -> SummarizeResponse:
+    summary = Summarizer.summarize(request.text, request.max_sentences)
+    return SummarizeResponse(summary=summary)

--- a/backend/shared/models.py
+++ b/backend/shared/models.py
@@ -54,3 +54,21 @@ class ExtractResponse(BaseModel):
     title: str
     language: str
     chars: int
+
+
+class SummarizeRequest(BaseModel):
+    text: str
+    max_sentences: int = 3
+
+
+class SummarizeResponse(BaseModel):
+    summary: str
+
+
+class BiasRequest(BaseModel):
+    source: str
+
+
+class BiasResponse(BaseModel):
+    bias: str
+    bias_score: int

--- a/backend/tests/test_bias.py
+++ b/backend/tests/test_bias.py
@@ -1,0 +1,36 @@
+import unittest
+
+from backend.services.bias import BiasAnnotator, bias_endpoint
+from backend.shared.models import BiasRequest
+
+
+class BiasTests(unittest.TestCase):
+    def setUp(self) -> None:
+        try:
+            from fastapi.testclient import TestClient
+
+            from backend.main import app
+
+            self.client = TestClient(app)
+        except Exception:
+            self.client = None
+
+    def test_bias_annotator_class(self):
+        result = BiasAnnotator.annotate("Fox News")
+        self.assertEqual(result.bias, "Right")
+        self.assertEqual(result.bias_score, 10)
+
+    def test_bias_function(self):
+        resp = bias_endpoint(BiasRequest(source="MSNBC"))
+        self.assertEqual(resp.dict(), {"bias": "Left", "bias_score": 10})
+
+    def test_bias_endpoint(self):
+        if not self.client:
+            self.skipTest("no fastapi")
+        response = self.client.post("/bias/", json={"source": "AP"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"bias": "Center", "bias_score": 5})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_summarize.py
+++ b/backend/tests/test_summarize.py
@@ -1,0 +1,39 @@
+import unittest
+
+from backend.services.summarize import Summarizer, summarize_endpoint
+from backend.shared.models import SummarizeRequest
+
+
+class SummarizeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        try:
+            from fastapi.testclient import TestClient
+
+            from backend.main import app
+
+            self.client = TestClient(app)
+        except Exception:
+            self.client = None
+
+    def test_summarizer_class(self):
+        text = "A. B. C. D."
+        summary = Summarizer.summarize(text, max_sentences=2)
+        self.assertEqual(summary, "A. B.")
+
+    def test_summarize_function(self):
+        resp = summarize_endpoint(SummarizeRequest(text="A. B. C.", max_sentences=1))
+        self.assertEqual(resp.dict(), {"summary": "A."})
+
+    def test_summarize_endpoint(self):
+        if not self.client:
+            self.skipTest("no fastapi")
+        response = self.client.post(
+            "/summarize/",
+            json={"text": "A. B. C.", "max_sentences": 2},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"summary": "A. B."})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add summarizer microservice and API
- add bias annotator microservice and API
- extend shared models for new endpoints
- register new routers
- test summarizer and bias logic and endpoints

## Testing
- `python -m unittest discover backend/tests`