### PR TITLE
Add perspectives pipeline

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -7,6 +7,7 @@ from backend.services.queries import router as queries_router
 from backend.services.retrieval import router as retrieval_router
 from backend.services.summarize import router as summarize_router
 from backend.services.topics import router as topics_router
+from backend.services.perspectives import router as perspectives_router
 
 app = FastAPI()
 
@@ -17,6 +18,11 @@ app.include_router(dedup_router, prefix="/dedup", tags=["dedup"])
 app.include_router(extract_router, prefix="/extract", tags=["extract"])
 app.include_router(summarize_router, prefix="/summarize", tags=["summarize"])
 app.include_router(bias_router, prefix="/bias", tags=["bias"])
+app.include_router(
+    perspectives_router,
+    prefix="/v1/perspectives",
+    tags=["perspectives"],
+)
 
 if __name__ == "__main__":
     import uvicorn

--- a/backend/services/perspectives/__init__.py
+++ b/backend/services/perspectives/__init__.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from backend.services.extract import ArticleExtractor
+from backend.services.topics import TopicDetector
+from backend.services.queries import QueryGenerator
+from backend.services.retrieval.aggregator import SearchAggregator
+from backend.services.dedup import Deduplicator
+from backend.services.summarize import Summarizer
+from backend.services.bias import BiasAnnotator
+from backend.shared.models import (
+    PerspectiveRequest,
+    PerspectiveResponse,
+)
+
+router = APIRouter()
+
+
+class PerspectivePipeline:
+    """Runs the full perspectives pipeline."""
+
+    @staticmethod
+    def run(url: str | None, html: str | None, force: bool = False) -> PerspectiveResponse:
+        extract = ArticleExtractor.extract(url, html, force)
+        topics = TopicDetector.get_topics(extract.clean_text)
+        queries = QueryGenerator.build_queries(topics)
+        articles = []
+        for q in queries:
+            articles.extend(SearchAggregator.search(q))
+        titles = [a.title for a in articles]
+        groups_models = Deduplicator.group_by_simhash(titles)
+        groups = [[g.representative, *g.duplicates] for g in groups_models]
+        summary = Summarizer.summarize(extract.clean_text, 3)
+        bias = BiasAnnotator.annotate(url or "")
+        return PerspectiveResponse(
+            topics=topics,
+            queries=queries,
+            articles=articles,
+            groups=groups,
+            summary=summary,
+            bias=bias.bias,
+            bias_score=bias.bias_score,
+        )
+
+
+@router.post("/", response_model=PerspectiveResponse)
+def generate_perspective(request: PerspectiveRequest) -> PerspectiveResponse:
+    return PerspectivePipeline.run(request.url, request.html, request.force)

--- a/backend/shared/models.py
+++ b/backend/shared/models.py
@@ -80,3 +80,19 @@ class BiasRequest(BaseModel):
 class BiasResponse(BaseModel):
     bias: str
     bias_score: int
+
+
+class PerspectiveRequest(BaseModel):
+    url: str | None = None
+    html: str | None = None
+    force: bool = False
+
+
+class PerspectiveResponse(BaseModel):
+    topics: List[str]
+    queries: List[str]
+    articles: List[Article]
+    groups: List[List[str]]
+    summary: str
+    bias: str
+    bias_score: int

--- a/backend/tests/test_perspectives.py
+++ b/backend/tests/test_perspectives.py
@@ -1,0 +1,99 @@
+import unittest
+from unittest.mock import patch
+
+from backend.services.perspectives import (
+    PerspectivePipeline,
+    generate_perspective,
+)
+from backend.shared.models import (
+    PerspectiveRequest,
+    Article,
+    DedupGroup,
+    ExtractResponse,
+    BiasResponse,
+)
+
+
+class PerspectivesTests(unittest.TestCase):
+    def setUp(self) -> None:
+        try:
+            from fastapi.testclient import TestClient
+            from backend.main import app
+
+            self.client = TestClient(app)
+        except Exception:
+            self.client = None
+
+    @patch("backend.services.perspectives.BiasAnnotator.annotate")
+    @patch("backend.services.perspectives.Summarizer.summarize")
+    @patch("backend.services.perspectives.Deduplicator.group_by_simhash")
+    @patch("backend.services.perspectives.SearchAggregator.search")
+    @patch("backend.services.perspectives.QueryGenerator.build_queries")
+    @patch("backend.services.perspectives.TopicDetector.get_topics")
+    @patch("backend.services.perspectives.ArticleExtractor.extract")
+    def test_pipeline_function(
+        self,
+        m_extract,
+        m_topics,
+        m_queries,
+        m_search,
+        m_dedup,
+        m_sum,
+        m_bias,
+    ) -> None:
+        m_extract.return_value = ExtractResponse(
+            clean_text="text", title="t", language="en", chars=4
+        )
+        m_topics.return_value = ["topic"]
+        m_queries.return_value = ["q"]
+        m_search.return_value = [Article(url="u", title="T")]
+        m_dedup.return_value = [DedupGroup(representative="T", duplicates=[])]
+        m_sum.return_value = "summary"
+        m_bias.return_value = BiasResponse(bias="Center", bias_score=5)
+
+        resp = generate_perspective(PerspectiveRequest(url="u"))
+        self.assertEqual(resp.summary, "summary")
+        self.assertEqual(resp.bias, "Center")
+        self.assertEqual(resp.topics, ["topic"])
+        self.assertEqual(resp.queries, ["q"])
+        self.assertEqual(resp.groups, [["T"]])
+        self.assertEqual(resp.articles, [Article(url="u", title="T")])
+
+    @patch("backend.services.perspectives.BiasAnnotator.annotate")
+    @patch("backend.services.perspectives.Summarizer.summarize")
+    @patch("backend.services.perspectives.Deduplicator.group_by_simhash")
+    @patch("backend.services.perspectives.SearchAggregator.search")
+    @patch("backend.services.perspectives.QueryGenerator.build_queries")
+    @patch("backend.services.perspectives.TopicDetector.get_topics")
+    @patch("backend.services.perspectives.ArticleExtractor.extract")
+    def test_pipeline_endpoint(
+        self,
+        m_extract,
+        m_topics,
+        m_queries,
+        m_search,
+        m_dedup,
+        m_sum,
+        m_bias,
+    ) -> None:
+        if not self.client:
+            self.skipTest("no fastapi")
+        m_extract.return_value = ExtractResponse(
+            clean_text="text", title="t", language="en", chars=4
+        )
+        m_topics.return_value = ["topic"]
+        m_queries.return_value = ["q"]
+        m_search.return_value = [Article(url="u", title="T")]
+        m_dedup.return_value = [DedupGroup(representative="T", duplicates=[])]
+        m_sum.return_value = "summary"
+        m_bias.return_value = BiasResponse(bias="Center", bias_score=5)
+
+        response = self.client.post("/v1/perspectives/", json={"url": "u"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["summary"], "summary")
+        self.assertEqual(response.json()["bias"], "Center")
+        self.assertEqual(response.json()["topics"], ["topic"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `PerspectiveRequest` and `PerspectiveResponse`
- implement `/v1/perspectives` pipeline orchestrating extraction → topics → queries → retrieval → dedup → summarization → bias
- expose router from `backend/main.py`
- test perspectives service with mocked subservices

## Testing
- `python -m unittest discover backend/tests -v`